### PR TITLE
[CITE-134] Added method in AuthorityEntryRepository to display authority entries specific to user

### DIFF
--- a/citesphere-model/src/main/java/edu/asu/diging/citesphere/data/AuthorityEntryRepository.java
+++ b/citesphere-model/src/main/java/edu/asu/diging/citesphere/data/AuthorityEntryRepository.java
@@ -15,5 +15,7 @@ public interface AuthorityEntryRepository extends PagingAndSortingRepository<Aut
     
     public List<IAuthorityEntry> findByUsernameAndUriOrderByName(String username, String uri);
     
-    public List<IAuthorityEntry> findByGroups(long groupId);
+    public List<IAuthorityEntry> findByGroupsOrderByName(long groupId);
+    
+    public List<IAuthorityEntry> findByUsernameAndGroupsOrderByName(String username, Long groupId);
 }


### PR DESCRIPTION
authorities specific to user

# Guidelines for Pull Requests

If you haven't yet read our code review guidelines, please do so, You can find them [here](https://diging.atlassian.net/wiki/spaces/DIGING/pages/2256076801/Code+Review+Guidelines).

Please confirm the following by adding an x for each item (turn `[ ]` into `[x]`).

- [x] I have removed all code style changes that are not necessary (e.g. changing blanks across the whole file that don’t need to be changed, adding empty lines in parts other than your own code)
- [x] I am not making any changes to files that don’t have any effect (e.g. imports added that don’t need to be added)
- [x] I do not have any sysout statements in my code or commented out code that isn’t needed anymore
- [x] I am not reformatting any files in the wrong format or without cause. 
- [x] I am not changing file encoding or line endings to something else than UTF-8, LF
- [x] My pull request does not show an insane amount of files being changed although my ticket only requires a few files being changed
- [x] I have added Javadoc/documentation where appropriate
- [x] I have added test cases where appropriate
- [x] I have explained any part of my code/implementation decisions that is not be self-explanatory

## Please provide a brief description of your ticket 
The group should be a citation group. Every user that has access to a group should be able to add/edit/delete authorities from that group. When a new authority is created a user should choose if that authority would be part of the citation group it is being created for (default) or just available to the user (no group).

An authority can belong to more than one group.

The "Manage Authority Entries" page should show the authorities categorized by group. E.g. a user would select a group and then see all authorities in that group.
  
## Anything else the reviewer needs to know?

... describe here ...
