### PR TITLE
Bug/cite 229 - Checking access of an upload in progress should be possible with the upload id.

### DIFF
--- a/citesphere-model/src/main/java/edu/asu/diging/citesphere/data/bib/CitationRepository.java
+++ b/citesphere-model/src/main/java/edu/asu/diging/citesphere/data/bib/CitationRepository.java
@@ -27,4 +27,6 @@ public interface CitationRepository extends MongoRepository<Citation, ObjectId> 
     List<ICitation> findByGilesUploadsDocumentId(String id);
     
     List<ICitation> findByGilesUploadsProgressId(String progressId);
+    
+    List<ICitation> findByGilesUploadsUploadId(String uploadId);
 }


### PR DESCRIPTION
# Guidelines for Pull Requests

If you haven't yet read our code review guidelines, please do so, You can find them [here](https://diging.atlassian.net/wiki/spaces/DIGING/pages/2256076801/Code+Review+Guidelines).

Please confirm the following by adding an x for each item (turn `[ ]` into `[x]`).

- [x] I have removed all code style changes that are not necessary (e.g. changing blanks across the whole file that don’t need to be changed, adding empty lines in parts other than your own code)
- [x] I am not making any changes to files that don’t have any effect (e.g. imports added that don’t need to be added)
- [x] I do not have any sysout statements in my code or commented out code that isn’t needed anymore
- [x] I am not reformatting any files in the wrong format or without cause. 
- [x] I am not changing file encoding or line endings to something else than UTF-8, LF
- [x] My pull request does not show an insane amount of files being changed although my ticket only requires a few files being changed
- [x] I have added Javadoc/documentation where appropriate
- [x] I have added test cases where appropriate
- [x] I have explained any part of my code/implementation decisions that is not be self-explanatory

## Please provide a brief description of your ticket 
Checking access of an upload in progress should be possible with the upload id.

...Put description here...
Right now, you need the documentId of a finished uploaded document or a progress id to check if a user has access to a giles upload. Citesphere, when checking the progress of an upload, needs to store the upload id (after the initial submission, there is just a progress id). And then in the CheckAccessController, it needs to also be possible to send the Upload Id.
 (this is for the API endpoint)

https://diging.atlassian.net/browse/CITE-229
  
## Anything else the reviewer needs to know?

... describe here ...
